### PR TITLE
Fix off-by-one error in consecutive days

### DIFF
--- a/model/optimality_constraints.py
+++ b/model/optimality_constraints.py
@@ -92,13 +92,13 @@ class OptimalityConstraints(BaseConstraints):
         )
 
     def add_consecutive_days(self, gamma, q):
-        self.model.addConstrs(
+        return self.model.addConstrs(
             (
                 quicksum(
-                    gamma[e, i_marked] for i_marked in range(i, i + self.limit_on_consecutive_days)
+                    gamma[e, i_marked] for i_marked in self.get_consecutive_days_time_window(i)
                 )
                 - self.limit_on_consecutive_days
-                <= q["con"][e, i]
+                <= q["con"][e, i] - 1
                 for e in self.employees
                 for i in range(len(self.days) - self.limit_on_consecutive_days)
             ),
@@ -114,3 +114,6 @@ class OptimalityConstraints(BaseConstraints):
             ),
             name="if_employee_e_works_day_i",
         )
+
+    def get_consecutive_days_time_window(self, day):
+        return range(day, day + self.limit_on_consecutive_days)

--- a/tests/test_optimality_constraints.py
+++ b/tests/test_optimality_constraints.py
@@ -1,0 +1,20 @@
+import pytest
+
+from model.optimality_model import OptimalityModel
+
+
+@pytest.fixture()
+def optimality_model():
+    return OptimalityModel(name="test_model")
+
+
+@pytest.fixture()
+def optimality_constraints(optimality_model):
+    return optimality_model.constraints
+
+
+def test_get_consecutive_days_time_window(optimality_constraints):
+
+    time_window = optimality_constraints.get_consecutive_days_time_window(0)
+
+    assert len(time_window) == optimality_constraints.limit_on_consecutive_days


### PR DESCRIPTION
See issue #31 for background. Fix the issue by subtracting 1 from RHS, and thus forcing `q` to take a value of 1 for the case where `LHS == 0`. 

Remember to close the issue after approving this PR.