### PR TITLE
Improvements to xml loader and add new tests

### DIFF
--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,84 +1,14 @@
 import pytest
-import sys
-from pathlib import Path
 
-from utils.const import DAYS_IN_WEEK
+from utils.const import DEFAULT_COMPETENCY, DAYS_IN_WEEK
 from xml_loader import xml_loader
 
 
-loader_path = Path(__file__).resolve().parents[1]
-sys.path.insert(1, str(loader_path))
-from xml_loader.xml_loader import *
-import xml.etree.ElementTree as ET
+def test_loading_demand():
 
-data_folder = (
-    Path(__file__).resolve().parents[2]
-    / "flexible_employee_scheduling_data/xml data/Artifical Test Instances/"
-)
+    root = xml_loader.get_root("problem12")
+    demand_definitions = xml_loader.get_demand_definitions(root)
 
-
-@pytest.fixture
-def employees():
-    root = ET.parse(data_folder / "problem12.xml").getroot()
-    competencies = get_competencies(root)
-    employees = get_staff(root, competencies)
-    return employees
-
-
-@pytest.fixture
-def days_with_demand():
-    root = ET.parse(data_folder / "problem12.xml").getroot()
-    return get_days_with_demand(root)
-
-
-@pytest.fixture
-def demand_definitions():
-    root = ET.parse(data_folder / "problem12.xml").getroot()
-    return get_demand_definitions(root)
-
-
-@pytest.fixture
-def rest_rules():
-    root = ET.parse(data_folder / "problem19.xml").getroot()
-    competencies = get_competencies(root)
-    return (
-        get_weekly_rest_rules(root),
-        get_daily_rest_rules(root),
-        get_staff(root, competencies),
-    )
-
-
-def test_loading_competencies(competencies):
-    assert len(competencies) == 3, "Expected 3 competencies got %d" % (len(competencies))
-
-
-def test_loading_days(days):
-    assert len(days) == 7, "Expected 7 days got %d" % (len(days))
-
-
-def test_loading_employees(employees):
-    assert len(employees) == 1, "Expected 1 employee got %d" % (len(employees))
-    for employee in employees:
-        assert employee.competencies == [
-            "Competence1",
-            "Competence2",
-            "Competence3",
-        ], "Employee 1 should have three competencies"
-        assert employee.contracted_hours == 37, "Employee 1 should have 37 contracted hours"
-
-
-def test_days_with_demand(days_with_demand):
-    for day in range(4):
-        assert (
-            days_with_demand[day].demand_id == "DayDemandId1"
-        ), "Expect the correct demand definition for the first four days"
-    for day in range(4, len(days_with_demand)):
-        assert (
-            days_with_demand[day].demand_id == "DayDemandId2"
-        ), "Expect the correct demand definition for the last three days"
-
-
-def test_loading_demand(demand_definitions):
     assert len(demand_definitions) == 2, "Should be two demand definitions"
 
     dem1 = demand_definitions[0]
@@ -99,27 +29,20 @@ def test_loading_demand(demand_definitions):
     assert dem2.maximum == [3, 4, 5, 6]
 
 
-def test_rest_rules(rest_rules):
-    assert rest_rules[0][0].rest_id == "WeeklyRestRule1"
-    assert rest_rules[1][0].rest_id == "DayRestRule1"
+def test_rest_rules():
 
-    for employee in rest_rules[2]:
+    root = xml_loader.get_root("problem19")
+    daily_rest_rules = xml_loader.get_daily_rest_rules(root)
+    weekly_rest_rules = xml_loader.get_weekly_rest_rules(root)
+
+    competencies = xml_loader.get_competencies(root)
+    staff = xml_loader.get_staff(root, competencies)
+
+    assert weekly_rest_rules[0].rest_id == "WeeklyRestRule1"
+
+    for employee in staff:
         assert employee.weekly_rest_hours == 36
         assert employee.daily_rest_hours == 9
-
-
-
-
-# todo: NEW TESTS
-
-@pytest.fixture()
-def get_competencies(get_root):
-
-    def _get_competencies(problem):
-        root = get_root(problem)
-        return xml_loader.get_competencies(root)
-
-    return _get_competencies
 
 
 @pytest.mark.parametrize("problem, expected", [
@@ -141,20 +64,20 @@ def test_get_data_folder(problem, expected):
 ])
 def test_get_competencies(problem, expected):
 
-    root = get_root(problem)
+    root = xml_loader.get_root(problem)
     competencies = xml_loader.get_competencies(root)
 
     assert competencies == expected
 
 
 @pytest.mark.parametrize("problem, expected", [
-    ("rproblem2", [i for i in range(2)]),
-    ("rproblem3", [i for i in range(4)]),
-    ("problem12", [i for i in range(3)])
+    ("rproblem2", [i for i in range(10*DAYS_IN_WEEK)]),
+    ("rproblem3", [i for i in range(4*DAYS_IN_WEEK)]),
+    ("problem12", [i for i in range(7)])
 ])
 def test_get_days(problem, expected):
 
-    root = get_root(problem)
+    root = xml_loader.get_root(problem)
     days = xml_loader.get_days(root)
 
     assert days == expected
@@ -163,14 +86,28 @@ def test_get_days(problem, expected):
 @pytest.mark.parametrize("problem, expected_number, expected_contracted, expected_competencies", [
     ("problem12", 1, 37, ["Competence1", "Competence2", "Competence3"])
 ])
-def test_get_employees(problem, expected_number, expected_contracted, expected_competencies):
+def test_get_staff(problem, expected_number, expected_contracted, expected_competencies):
 
-    root = get_root(problem)
+    root = xml_loader.get_root(problem)
     competencies = xml_loader.get_competencies(root)
-    employees = xml_loader.get_employees(root, competencies)
+    staff = xml_loader.get_staff(root, competencies)
 
-    assert len(employees) == expected_number
-    assert employees[0].contracted_hours == expected_contracted
-    assert employees[0].competencies == expected_competencies
+    assert len(staff) == expected_number
+    assert staff[0].contracted_hours == expected_contracted
+    assert staff[0].competencies == expected_competencies
+
+
+@pytest.mark.parametrize("problem, expected", [
+    ("problem12",
+     ["DayDemandId1", "DayDemandId1", "DayDemandId1", "DayDemandId1", "DayDemandId2", "DayDemandId2", "DayDemandId2"])
+])
+def test_get_days_with_demand(problem, expected):
+
+    root = xml_loader.get_root(problem)
+    days_with_demand = xml_loader.get_days_with_demand(root)
+
+    demand_ids = [day_demand.demand_id for day_demand in days_with_demand.values()]
+
+    assert demand_ids == expected
 
 

--- a/xml_loader/xml_loader.py
+++ b/xml_loader/xml_loader.py
@@ -143,10 +143,26 @@ def set_competency_for_employee(competencies, employee, schedule_row):
         employee.set_competency(DEFAULT_COMPETENCY)
 
 
-def get_root(problem_name):
-    data_folder = (
-        Path(__file__).resolve().parents[2]
-        / "flexible_employee_scheduling_data/xml data/Real Instances/"
-    )
-    root = ET.parse(data_folder / (problem_name + ".xml")).getroot()
-    return root
+def get_root(problem):
+
+    data_folder = get_data_folder(problem)
+
+    return ET.parse(data_folder / (problem + ".xml")).getroot()
+
+
+def get_data_folder(problem):
+
+    if "rproblem" in problem:
+        data_folder = (
+                Path(__file__).resolve().parents[2]
+                / "flexible_employee_scheduling_data/xml data/Real Instances/"
+        )
+    elif "problem" in problem:
+        data_folder = (
+                Path(__file__).resolve().parents[2]
+                / "flexible_employee_scheduling_data/xml data/Artificial Instances/"
+        )
+    else:
+        raise ValueError("Not a valid problem! The problem_name should include 'problem' or 'rproblem'")
+
+    return data_folder


### PR DESCRIPTION
The code now automatically finds the correct data folder based on the problem name. This will reduce complexity and make the code cleaner. 

Rewrite all existing loader tests to follow pytest-standard. The tests are now more readable. Additionally, it is significantly easier to add multiple cases to a test. 

Add new test to increase test coverage.  