### PR TITLE
Improve copy

### DIFF
--- a/heuristic/delta_calculations.py
+++ b/heuristic/delta_calculations.py
@@ -6,20 +6,23 @@ from loguru import logger
 
 
 def delta_calculate_deviation_from_demand(state, competencies, t_covered_by_shift, employee_with_competencies, demand, destroy_repair_set):
+
     for c in competencies:
-        for e2,t,v in destroy_repair_set:
-            for t in t_covered_by_shift[t,v]:
+        for e2, t, v in destroy_repair_set:
+            for t in t_covered_by_shift[t, v]:
                 state.soft_vars["negative_deviation_from_demand"][c,t] = max(0,demand["ideal"][c,t] - sum(state.y[c,e,t] for e in employee_with_competencies[c]))
 
 def calculate_deviation_from_demand(state, competencies, t_covered_by_shift, employee_with_competencies, demand, destroy_repair_set):
+
     for c in competencies:
-        for e2,t,v in destroy_repair_set:
-            for t in t_covered_by_shift[t,v]:
-                if(demand["ideal"].get((c,t))):
+        for e2, t, v in destroy_repair_set:
+            for t in t_covered_by_shift[t, v]:
+                if demand["ideal"].get((c, t)):
                     state.soft_vars["deviation_from_ideal_demand"][c,t] = sum(state.y[c,e,t] for e in employee_with_competencies[c]) - demand["ideal"][c,t]
 
 
 def delta_calculate_negative_deviation_from_contracted_hours(state, employees, contracted_hours, weeks, time_periods_in_week, competencies, time_step):
+
     for e in employees:
         for j in weeks:
             state.soft_vars["deviation_contracted_hours"][e,j] = (contracted_hours[e] - sum(time_step * state.y[c,e,t]
@@ -46,23 +49,24 @@ def calculate_weekly_rest(state, shifts_at_week, employees, weeks):
 
     for key in actual_shifts.keys():
         week = int(weeks.index(key[1]))
-        if(len(actual_shifts[key]) == 0):
+        if len(actual_shifts[key]) == 0:
             off_shift_periods[key] = [(important[week], float((important[week + 1] - important[week])))]
 
         else:
-            if(actual_shifts[key][0][0] - important[week] >= 36):
+            if actual_shifts[key][0][0] - important[week] >= 36:
                 off_shift_periods[key].append((important[week], actual_shifts[key][0][0] - important[week]))
 
-            if(important[week + 1] - (actual_shifts[key][-1][0] + actual_shifts[key][-1][1]) >= 36):
+            if important[week + 1] - (actual_shifts[key][-1][0] + actual_shifts[key][-1][1]) >= 36:
                 off_shift_periods[key].append(((actual_shifts[key][-1][0] + actual_shifts[key][-1][1]), important[week + 1] - (actual_shifts[key][-1][0] + actual_shifts[key][-1][1])))
 
             for i in range(len(actual_shifts[key])-1):
-                if(actual_shifts[key][i+1][0] - (actual_shifts[key][i][0] + actual_shifts[key][i][1]) >= 36):
+                if actual_shifts[key][i + 1][0] - (actual_shifts[key][i][0] + actual_shifts[key][i][1]) >= 36:
                     off_shift_periods[key].append(((actual_shifts[key][i][0] + actual_shifts[key][i][1]), actual_shifts[key][i+1][0] - (actual_shifts[key][i][0] + actual_shifts[key][i][1])))
 
-        if(len(off_shift_periods[key]) != 0):
-            state.w[key] = max(off_shift_periods[key],key=itemgetter(1))
-            state.hard_vars["weekly_off_shift_error"][key] = 0
+        if len(off_shift_periods[key]) != 0:
+            state.w[key] = max(off_shift_periods[key], key=itemgetter(1))
+            if key in state.hard_vars["weekly_off_shift_error"]:
+                del state.hard_vars["weekly_off_shift_error"][key]
         else:
             state.hard_vars["weekly_off_shift_error"][key] = 1
             state.w[key] = (0, 0.0)
@@ -140,42 +144,33 @@ def calculate_f_for_employee(L_C_D, days, e, saturdays, state, weeks, weights):
 
 
 def below_minimum_demand(state, repair_destroy_set, employee_with_competencies, demand, competencies, t_covered_by_shift):
+
     for c in competencies:
-        for e2,t1,v1 in repair_destroy_set:
+        for e2, t1, v1 in repair_destroy_set:
             for t in t_covered_by_shift[t1,v1]:
-                if (c,t) in state.hard_vars["below_minimum_demand"]:
+                if (c, t) in demand["min"]:
                     state.hard_vars["below_minimum_demand"][c,t] = max(0, (demand["min"][c,t] - sum(state.y[c,e,t] for e in employee_with_competencies[c])))
 
 
 def above_maximum_demand(state, repair_destroy_set, employee_with_competencies, demand, competencies, t_covered_by_shift):
+
     for c in competencies:
-        for e2,t1,v1 in repair_destroy_set:
+        for e2, t1, v1 in repair_destroy_set:
             for t in t_covered_by_shift[t1,v1]:
-                if (c,t) in state.hard_vars["above_maximum_demand"]:
+                if (c, t) in demand["max"]:
                     state.hard_vars["above_maximum_demand"][c,t] = max(0, (sum(state.y[c,e,t] for e in employee_with_competencies[c]) - demand["max"][c,t]))
+
 
 def more_than_one_shift_per_day(state, employees, demand, shifts_at_day, days):
     for e in employees:
         for i in days:
             state.hard_vars["more_than_one_shift_per_day"][e,i] = max(0, (sum(state.x[e,t,v] for t,v in shifts_at_day[i]) - 1))
 
+
 def cover_multiple_demand_periods(state, repair_set, t_covered_by_shift, competencies):
     for e,t1,v1 in repair_set:
         for t in t_covered_by_shift[t1,v1]:
             state.hard_vars["cover_multiple_demand_periods"][e,t] = max(0,(sum(state.y[c,e,t] for c in competencies if state.y.get((c,e,t))) - 1))
-
-# I think this is not needed, but I am not sure yet
-#def weekly_off_shift_error(state, repair_destroy_set, weeks, off_shift_in_week):
- #   for e,t,v in repair_destroy_set:
-  #      for j in weeks:
-   #         state.hard_vars["weekly_off_shift_error"][e,j] = max(0,(abs(sum(state.w[e,t,v] for t,v in off_shift_in_week[j]) - 1)))
-
-#This check might also not be needed as our off-shifts are based on time between shifts. As with the constraint above I am not sure
-# def no_work_during_off_shift(state, repair_destroy_set, competencies, t_covered_by_off_shift, off_shifts):
-#     for e,t2,v2 in repair_destroy_set:
-#         for t1,v1 in off_shifts: 
-#             if state.w[e,t1,v1] != 0:
-#                 state.hard_vars["no_work_during_off_shift"][e,t1] = sum(state.y[c,e,t] for c in competencies for t in t_covered_by_off_shift[t1,v1])
 
 
 # This check might not be needed if we always set y's when we set x.
@@ -191,17 +186,32 @@ def calculate_daily_rest_error(state, destroy_and_repair, invalid_shifts, shift_
 
     days_in_destroy = [(e,int(t/24)) for e,t,v in destroy]
 
-    for e,i in days_in_destroy:
-        state.hard_vars["daily_rest_error"][e, i] = 0
+    for e, i in days_in_destroy:
+        if (e, i) in state.hard_vars["daily_rest_error"]:
+            del state.hard_vars["daily_rest_error"][e, i]
 
-    for e,t,v in repair:
+    for e, t, v in repair:
         i = int(t/24)
-        if((t,v) in invalid_shifts[e]):
+
+        if (t, v) in invalid_shifts[e]:
             state.hard_vars["daily_rest_error"][e, i] = 1
+
         if (t, v) in shift_combinations_violating_daily_rest[e]:
-            state.hard_vars["daily_rest_error"][e, i] = min(1, sum(state.x[e, t1, v1] for t1, v1 in shift_combinations_violating_daily_rest[e][t, v]))
+            value = min(1, sum(state.x[e, t1, v1]
+                               for t1, v1 in shift_combinations_violating_daily_rest[e][t, v]))
+            if value > 0:
+                state.hard_vars["daily_rest_error"][e, i] = value
+            elif (e, i) in state.hard_vars["daily_rest_error"]:
+                del state.hard_vars["daily_rest_error"][e, i]
+
         if (t, v) in shift_sequences_violating_daily_rest[e]:
-            state.hard_vars["daily_rest_error"][e, i] = max(0, sum(state.x[e, t2, v2] for t2, v2 in shift_sequences_violating_daily_rest[e][t, v]) - 1)
+            value = max(0, sum(state.x[e, t2, v2]
+                               for t2, v2 in shift_sequences_violating_daily_rest[e][t, v]) - 1)
+
+            if value > 0:
+                state.hard_vars["daily_rest_error"][e, i] = value
+            elif (e, i) in state.hard_vars["daily_rest_error"]:
+                del state.hard_vars["daily_rest_error"][e, i]
 
 
 def hard_constraint_penalties(state):

--- a/heuristic/delta_calculations.py
+++ b/heuristic/delta_calculations.py
@@ -25,7 +25,7 @@ def delta_calculate_negative_deviation_from_contracted_hours(state, employees, c
             state.soft_vars["deviation_contracted_hours"][e,j] = (contracted_hours[e] - sum(time_step * state.y[c,e,t]
                 for c in competencies
                 for t in time_periods_in_week[c, j]))
-        
+
         state.hard_vars["delta_positive_contracted_hours"][e] = -min(0, sum(state.soft_vars["deviation_contracted_hours"][e,j] for j in weeks))
 
 def calculate_weekly_rest(state, shifts_at_week, employees, weeks):
@@ -67,36 +67,36 @@ def calculate_weekly_rest(state, shifts_at_week, employees, weeks):
             state.hard_vars["weekly_off_shift_error"][key] = 1
             state.w[key] = (0, 0.0)
 
-        
 
-#Weaknesses: 
+
+#Weaknesses:
 # 1. It checks every weekend instead of only the weekends that have been destroyed or repaired
 def calculate_partial_weekends(state, employees, shifts_at_day, saturdays):
     for e in employees:
         for i in saturdays:
             state.soft_vars["partial_weekends"][e,i] = abs(sum(state.x[e,t,v] for t,v in shifts_at_day[i]) - sum(state.x[e,t,v] for t,v in shifts_at_day[i+1]))
 
-#Weaknesses: 
+#Weaknesses:
 # 1. It checks every possible combination of isolated working days instead of the ones that could be affected by the destroy and repair
 def calculate_isolated_working_days(state, employees, shifts_at_day, days):
     for e in employees:
         for i in range(len(days)-2):
-            state.soft_vars["isolated_working_days"][e,i+1] = max(0,(-sum(state.x[e,t,v] for t,v in shifts_at_day[i]) 
-            + sum(state.x[e,t,v] for t,v in shifts_at_day[i+1]) 
+            state.soft_vars["isolated_working_days"][e,i+1] = max(0,(-sum(state.x[e,t,v] for t,v in shifts_at_day[i])
+            + sum(state.x[e,t,v] for t,v in shifts_at_day[i+1])
             - sum(state.x[e,t,v] for t,v in shifts_at_day[i+2])))
 
 
-#Weaknesses: 
+#Weaknesses:
 # 1. It checks every possible combination of isolated off days instead of the ones that could be affected by the destroy and repair
 def calculate_isolated_off_days(state, employees, shifts_at_day, days):
     for e in employees:
         for i in range(len(days)-2):
-            state.soft_vars["isolated_off_days"][e,i+1] = max(0,(sum(state.x[e,t,v] for t,v in shifts_at_day[i]) 
-            - sum(state.x[e,t,v] for t,v in shifts_at_day[i+1]) 
+            state.soft_vars["isolated_off_days"][e,i+1] = max(0,(sum(state.x[e,t,v] for t,v in shifts_at_day[i])
+            - sum(state.x[e,t,v] for t,v in shifts_at_day[i+1])
             + sum(state.x[e,t,v] for t,v in shifts_at_day[i+2])-1))
 
 
-#Weaknesses: 
+#Weaknesses:
 # 1. It checks every possible combination of consecutive days instead of the ones that could be affected by the destroy and repair
 def calculate_consecutive_days(state, employees, shifts_at_day, L_C_D, days):
     for e in employees:
@@ -188,9 +188,9 @@ def mapping_shift_to_demand(state, repair_destroy_set, t_covered_by_shift, shift
 def calculate_daily_rest_error(state, destroy_and_repair, invalid_shifts, shift_combinations_violating_daily_rest, shift_sequences_violating_daily_rest):
     destroy = destroy_and_repair[0]
     repair = destroy_and_repair[1]
-    
+
     days_in_destroy = [(e,int(t/24)) for e,t,v in destroy]
-    
+
     for e,i in days_in_destroy:
         state.hard_vars["daily_rest_error"][e, i] = 0
 
@@ -254,85 +254,111 @@ def calc_weekly_objective_function(state, competencies, time_periods_in_week, co
         if setting == "worst":
             value[j] = (
                         sum(min(100, state.w[e, j][1]) for e in employees)
-                        - sum(abs(state.soft_vars["deviation_from_ideal_demand"][c,t]) for c in competencies for t in time_periods_in_week[c, j])
-                        - sum(state.soft_vars["partial_weekends"][e, (5 + j * 7)] for e in employees)
-                        - sum(state.soft_vars["isolated_working_days"][e, i + 1] + state.soft_vars["isolated_off_days"][e, i + 1] for e in employees for i in range(len(days_in_week)-2))
-                        - sum(state.soft_vars["consecutive_days"][e,i] for e in employees for i in range(len(days_in_week)-L_C_D))
-                        - 10 * sum(state.hard_vars["below_minimum_demand"][c, t] + state.hard_vars["above_maximum_demand"][c, t] for c in competencies for j in weeks for t in time_periods_in_week[c, j])
-                        - 10 * sum(state.hard_vars["more_than_one_shift_per_day"][e, i] for e in employees for i in days_in_week)
-                        - 10 * sum(state.hard_vars["cover_multiple_demand_periods"][e,t] for e in employees for j in weeks for t in combined_time_periods_in_week[j])
-                        - max(0, sum(state.soft_vars["deviation_contracted_hours"][e,j] for e in employees))
-                        - 10 * sum(state.hard_vars["delta_positive_contracted_hours"][e] for e in employees)
-                        - 10 * sum(state.hard_vars["daily_rest_error"][e,i] for e in employees for i in days_in_week)
+
+                        - sum(abs(state.soft_vars["deviation_from_ideal_demand"][c, t])
+                              for c in competencies
+                              for t in time_periods_in_week[c, j]
+                              )
+
+                        - sum(state.soft_vars["partial_weekends"][e, (5 + j * 7)]
+                              for e in employees
+                              )
+
+                        - sum(state.soft_vars["isolated_working_days"][e, i + 1]
+                              +
+                              state.soft_vars["isolated_off_days"][e, i + 1]
+                              for e in employees
+                              for i in range(len(days_in_week)-2)
+                              )
+
+                        - sum(state.soft_vars["consecutive_days"][e, i]
+                              for e in employees
+                              for i in range(len(days_in_week)-L_C_D)
+                              )
+
+                        - 10 * sum(state.hard_vars["below_minimum_demand"].get((c, t), 0)
+                                   +
+                                   state.hard_vars["above_maximum_demand"].get((c, t), 0)
+                                   for c in competencies
+                                   for j in weeks
+                                   for t in time_periods_in_week[c, j]
+                                   )
+
+                        - 10 * sum(state.hard_vars["more_than_one_shift_per_day"].get((e, i), 0)
+                                   for e in employees for i in days_in_week
+                                   )
+
+                        - 10 * sum(state.hard_vars["cover_multiple_demand_periods"].get((e, t), 0)
+                                   for e in employees
+                                   for j in weeks
+                                   for t in combined_time_periods_in_week[j]
+                                   )
+
+                        - max(0,
+                              sum(state.soft_vars["deviation_contracted_hours"].get((e, j), 0)
+                                  for e in employees
+                                  )
+                              )
+
+                        - 10 * sum(state.hard_vars["delta_positive_contracted_hours"].get(e, 0)
+                                   for e in employees
+                                   )
+
+                        - 10 * sum(state.hard_vars["daily_rest_error"].get((e, i), 0)
+                                   for e in employees
+                                   for i in days_in_week)
             )
 
         else:
 
             value[j] = (
-                sum(
-                    min(100, state.w[e, j][1])
-                    for e in employees
-                )
+                sum(min(100, state.w[e, j][1])
+                    for e in employees)
 
-                #- 3 * sum(abs(state.soft_vars["deviation_from_ideal_demand"][c,t]) for c in competencies for t in time_periods_in_week[c, j])
+                - sum(state.soft_vars["partial_weekends"][e, (5 + j * 7)]
+                      for e in employees)
 
-                - sum(
-                    state.soft_vars["partial_weekends"][e, (5 + j * 7)]
-                    for e in employees
-                )
+                - sum(state.soft_vars["isolated_working_days"][e, i + 1]
+                      +
+                      state.soft_vars["isolated_off_days"][e, i + 1]
+                      for e in employees
+                      for i in range(len(days_in_week)-2))
 
-                - sum(
-                    state.soft_vars["isolated_working_days"][e, i + 1]
-                    + state.soft_vars["isolated_off_days"][e, i + 1]
-                    for e in employees
-                    for i in range(len(days_in_week)-2)
-                )
+                - sum(state.soft_vars["consecutive_days"][e, i]
+                      for e in employees
+                      for i in range(len(days_in_week)-L_C_D))
 
-                - sum(
-                    state.soft_vars["consecutive_days"][e, i]
-                    for e in employees
-                    for i in range(len(days_in_week)-L_C_D)
-                )
+                - 5 * sum(state.hard_vars["below_minimum_demand"].get((c, t), 0)
+                          +
+                          state.hard_vars["above_maximum_demand"].get((c, t), 0)
+                          for c in competencies
+                          for j in weeks
+                          for t in time_periods_in_week[c, j])
 
-                - 5 * sum(
-                    state.hard_vars["below_minimum_demand"][c, t]
-                    + state.hard_vars["above_maximum_demand"][c, t]
-                    for c in competencies
-                    for j in weeks
-                    for t in time_periods_in_week[c, j])
 
-                - 10 * sum(
-                    state.hard_vars["more_than_one_shift_per_day"][e, i]
-                    for e in employees
-                    for i in days_in_week
-                )
+                - 10 * sum(state.hard_vars["more_than_one_shift_per_day"].get((e, i), 0)
+                           for e in employees
+                           for i in days_in_week)
 
-                - 10 * sum(
-                    state.hard_vars["cover_multiple_demand_periods"][e, t]
-                    for e in employees
-                    for j in weeks
-                    for t in combined_time_periods_in_week[j]
-                )
+                - 10 * sum(state.hard_vars["cover_multiple_demand_periods"].get((e, t), 0)
+                           for e in employees
+                           for j in weeks
+                           for t in combined_time_periods_in_week[j])
 
                 - 5 * max(
                     0,
                     sum(state.soft_vars["deviation_contracted_hours"][e, j]
-                        for e in employees
-                        )
-                )
+                        for e in employees))
 
-                - 10 * sum(state.hard_vars["weekly_off_shift_error"][e, j]
-                           for e in employees
-                           )
+                - 10 * sum(state.hard_vars["weekly_off_shift_error"].get((e, j), 0)
+                           for e in employees)
 
                 - 100 * sum(state.hard_vars["delta_positive_contracted_hours"][e]
-                            for e in employees
-                            )
+                            for e in employees)
 
                 - 100 * competency_score
-                - 10 * sum(state.hard_vars["daily_rest_error"][e,i]
-                           for e in employees for i in days_in_week
-                           )
+                - 10 * sum(state.hard_vars["daily_rest_error"].get((e, i), 0)
+                           for e in employees for i in days_in_week)
                 )
 
     if setting == "worst":
@@ -344,17 +370,41 @@ def calc_weekly_objective_function(state, competencies, time_periods_in_week, co
 
 def regret_objective_function(state, employee, off_shifts, saturdays, days, L_C_D, weeks, contracted_hours, competencies, t_changed, competency_score):
 
-    return (+ sum(min(100, state.w[employee,j][1]) for j in weeks)
-            + max(0, sum(state.soft_vars["deviation_contracted_hours"][employee,j] for j in weeks))
-            - sum(state.soft_vars["partial_weekends"][employee,i] for i in saturdays)
-            - sum(state.soft_vars["isolated_working_days"][employee,i+1] + state.soft_vars["isolated_off_days"][employee,i+1] for i in range(len(days)-2))
-            - sum(state.soft_vars["consecutive_days"][employee,i] for i in range(len(days)-L_C_D))
-            - 10 * sum(state.hard_vars["below_minimum_demand"][c,t] for c in competencies for t in t_changed if (c,t) in state.hard_vars["below_minimum_demand"])
-            - 10 * sum(state.hard_vars["above_maximum_demand"][c,t] for c in competencies for t in t_changed if (c,t) in state.hard_vars["above_maximum_demand"])
-            - 10 * sum(state.hard_vars["more_than_one_shift_per_day"][employee, i] for i in days)
-            - 10 * sum(state.hard_vars["cover_multiple_demand_periods"][employee, t] for t in t_changed)
-            - 10 * sum(state.hard_vars["weekly_off_shift_error"][employee, j] for j in weeks)
-            - 10 * sum(state.hard_vars["mapping_shift_to_demand"][employee, t] for t in t_changed)
-            - 10 * state.hard_vars["delta_positive_contracted_hours"][employee]
+    return (+ sum(min(100, state.w[employee, j][1]) for j in weeks)
+
+            + max(0, sum(state.soft_vars["deviation_contracted_hours"][employee, j]
+                         for j in weeks))
+
+            - sum(state.soft_vars["partial_weekends"][employee, i]
+                  for i in saturdays)
+
+            - sum(state.soft_vars["isolated_working_days"][employee, i+1]
+                  +
+                  state.soft_vars["isolated_off_days"][employee, i+1]
+                  for i in range(len(days)-2))
+
+            - sum(state.soft_vars["consecutive_days"][employee, i]
+                  for i in range(len(days)-L_C_D))
+
+            - 10 * sum(state.hard_vars["below_minimum_demand"].get((c, t), 0)
+                       for c in competencies for t in t_changed)
+
+            - 10 * sum(state.hard_vars["above_maximum_demand"].get((c, t), 0)
+                       for c in competencies for t in t_changed)
+
+            - 10 * sum(state.hard_vars["more_than_one_shift_per_day"].get((employee, i), 0)
+                       for i in days)
+
+            - 10 * sum(state.hard_vars["cover_multiple_demand_periods"].get((employee, t), 0)
+                       for t in t_changed)
+
+            - 10 * sum(state.hard_vars["weekly_off_shift_error"].get((employee, j), 0)
+                       for j in weeks)
+
+            - 10 * sum(state.hard_vars["mapping_shift_to_demand"].get((employee, t), 0)
+                       for t in t_changed)
+
+            - 10 * state.hard_vars["delta_positive_contracted_hours"].get(employee, 0)
+
             - 100 * competency_score
-    )
+            )

--- a/heuristic/heuristic_calculations.py
+++ b/heuristic/heuristic_calculations.py
@@ -1,6 +1,4 @@
 from collections import defaultdict
-from operator import itemgetter
-from copy import copy
 
 from loguru import logger
 
@@ -26,15 +24,16 @@ def calculate_weekly_rest(data, x, w):
     important = [7 * 24 * i for i in range(len(data["time"]["weeks"]) + 1)]
     for key in actual_shifts.keys():
         week = int(key[1])
-        if(len(actual_shifts[key]) == 0):
+        if len(actual_shifts[key]) == 0:
             off_shift_periods[key] = [(important[week], float((important[week + 1] - important[week])))]
 
         else:
-            if(actual_shifts[key][0][0] - important[week] >= 36):
+            if actual_shifts[key][0][0] - important[week] >= 36:
                 off_shift_periods[key].append((important[week], actual_shifts[key][0][0] - important[week]))
 
-            if(actual_shifts[key][0][0] - important[week] >= 36):
+            if actual_shifts[key][0][0] - important[week] >= 36:
                 off_shift_periods[key].append((important[week], actual_shifts[key][0][0] - important[week]))
+
 
 def calculate_negative_deviation_from_demand(data, y):
     delta = {}

--- a/heuristic/repair_operators.py
+++ b/heuristic/repair_operators.py
@@ -170,7 +170,7 @@ def worst_week_regret_repair(   shifts_in_week, competencies, t_covered_by_shift
         competencies_needed = tuple(set(y_s))
         possible_employees = [(e, score) for score, e in employee_with_competency_combination[competencies_needed] if (sum(state.x[e,t,v] for t,v in shifts_at_day[int(shift[0]/24)])) == 0]
 
-        if(len(possible_employees) == 0):
+        if len(possible_employees) == 0:
             impossible_shifts.append(shift)
             continue
 

--- a/main.py
+++ b/main.py
@@ -103,43 +103,14 @@ class ProblemRunner:
         }
 
         hard_variables = {
-            "below_minimum_demand": {
-                (c, t): 0
-                for c in self.data["competencies"]
-                for t in self.data["time"]["periods"][0][c]
-            },
-            "above_maximum_demand": {
-                (c, t): 0
-                for c in self.data["competencies"]
-                for t in self.data["time"]["periods"][0][c]
-            },
-            "more_than_one_shift_per_day": {
-                (e, i): 0
-                for e in self.data["staff"]["employees"]
-                for i in self.data["time"]["days"]
-            },
-            "cover_multiple_demand_periods": {
-                (e, t): 0
-                for e in self.data["staff"]["employees"]
-                for j in self.data["time"]["weeks"]
-                for t in self.data["time"]["combined_time_periods"][1][j]
-            },
-            "weekly_off_shift_error": {
-                (e, j): 0
-                for e in self.data["staff"]["employees"]
-                for j in self.data["time"]["weeks"]
-            },
-            "mapping_shift_to_demand": {
-                (c, t): 0
-                for c in self.data["competencies"]
-                for t in self.data["time"]["periods"][0]
-            },
-            "daily_rest_error": {
-                (e, i): 0
-                for e in self.data["staff"]["employees"]
-                for i in self.data["time"]["days"]},
-
-            "delta_positive_contracted_hours": {e: 0 for e in self.data["staff"]["employees"]},
+            "below_minimum_demand": {},
+            "above_maximum_demand": {},
+            "more_than_one_shift_per_day": {},
+            "cover_multiple_demand_periods": {},
+            "weekly_off_shift_error": {},
+            "mapping_shift_to_demand": {},
+            "daily_rest_error": {},
+            "delta_positive_contracted_hours": {},
         }
 
         objective_function, f = calculate_objective_function(self.data, soft_variables,


### PR DESCRIPTION
Improve copy by never storing 0-values in `hard_vars`. 

A runtime of 1 minute is used for all tests. The results show that the differences in performance are negligible. 

### Number of iterations 
| Problem | Master | Improved copy |
| :---         |     ---:      |          ---: |
| rproblem2   | 212 | 210 |
| rproblem3   | 9 | 9 |
| rproblem4   | 99 | 104 |
| rproblem5   | 89 | 86 |

### Best solution 
| Problem | Master | Improved copy |
| :---         |     ---:      |          ---: |
| rproblem2   | -84 | -84 |
| rproblem3   | -42430 | -42430 |
| rproblem4   |  380 | 380 |
| rproblem5   | 204 | 204 |
