### PR TITLE
Fix bug in is_legal

### DIFF
--- a/heuristic/state.py
+++ b/heuristic/state.py
@@ -29,22 +29,18 @@ class State:
     def is_legal(self):
         """ Returns True if all hard_vars is 0, otherwise will return False """
 
-        legal = (
+        return (
                 not any(self.hard_vars["below_minimum_demand"].values())
+                and not any(self.hard_vars["delta_positive_contracted_hours"].values())
                 and not any(self.hard_vars["above_maximum_demand"].values())
+                and not any(self.hard_vars["weekly_off_shift_error"].values())
                 and not any(self.hard_vars["more_than_one_shift_per_day"].values())
                 and not any(self.hard_vars["cover_multiple_demand_periods"].values())
-                and not any(self.hard_vars["weekly_off_shift_error"].values())
                 and not any(self.hard_vars["mapping_shift_to_demand"].values())
-                and not any(self.hard_vars["delta_positive_contracted_hours"].values())
                 )
 
-        penalty = hard_constraint_penalties(self)
 
-        if legal != (penalty == 0):
-            breakpoint()
 
-        return legal
 
     def copy(self):
         return State({"x": self.x.copy(), "y": self.y.copy(), "w": self.w.copy()},

--- a/heuristic/state.py
+++ b/heuristic/state.py
@@ -1,6 +1,8 @@
 from copy import copy
 from collections import defaultdict
 
+from loguru import logger
+
 from heuristic.delta_calculations import hard_constraint_penalties
 
 
@@ -27,9 +29,22 @@ class State:
     def is_legal(self):
         """ Returns True if all hard_vars is 0, otherwise will return False """
 
-        return not any(self.hard_vars.values())
+        legal = (
+                not any(self.hard_vars["below_minimum_demand"].values())
+                and not any(self.hard_vars["above_maximum_demand"].values())
+                and not any(self.hard_vars["more_than_one_shift_per_day"].values())
+                and not any(self.hard_vars["cover_multiple_demand_periods"].values())
+                and not any(self.hard_vars["weekly_off_shift_error"].values())
+                and not any(self.hard_vars["mapping_shift_to_demand"].values())
+                and not any(self.hard_vars["delta_positive_contracted_hours"].values())
+                )
 
+        penalty = hard_constraint_penalties(self)
 
+        if legal != (penalty == 0):
+            breakpoint()
+
+        return legal
 
     def copy(self):
         return State({"x": self.x.copy(), "y": self.y.copy(), "w": self.w.copy()},


### PR DESCRIPTION
Fixing bug in is_legal. 

This method has the benefit not summing and of early termination, i.e. if there is any value in `hard_vars["below_minimum_demand"]` the function will return False, and not bother with looping over the remaining variables. 

This means that we should place the hard variables we are most likely to violate early in the expression. 

If you want to test that this works as expected you can run the ALNS. If there is any deviation between the use of `any` and `hard_constraint_penalties == 0` the code will stop and you can inspect the outcome. 

I have tested on rproblem2 and rproblem3 with success. 