### PR TITLE
Extract demand per shift from SDP

### DIFF
--- a/heuristic/alns.py
+++ b/heuristic/alns.py
@@ -52,6 +52,7 @@ class ALNS:
 
         self.competencies = data["competencies"]
         self.demand = data["demand"]
+        self.demand_per_shift = data.get("demand_per_shift", None)
 
         self.days = data["time"]["days"]
         self.weeks = data["time"]["weeks"]

--- a/main.py
+++ b/main.py
@@ -177,10 +177,14 @@ class ProblemRunner:
 
         self.sdp.run_model()
 
-        used_shifts = self.sdp.get_used_shifts()
+        used_shifts, unused_shifts = self.sdp.get_used_shifts()
+
+        self.data["demand_per_shift"] = self.sdp.get_demand_per_shift()
+
         self.data["shifts"] = shift_generation.get_updated_shift_sets(
             self.problem, self.data, used_shifts
         )
+
         self.data["off_shifts"] = shift_generation.get_updated_off_shift_sets(
             self.data, used_shifts
         )

--- a/model/shift_design_model.py
+++ b/model/shift_design_model.py
@@ -52,19 +52,30 @@ class ShiftDesignModel:
 
     def get_used_shifts(self):
 
-        y = self.convert()
-        shifts = [shift for shift, used in y.items() if used == 1]
+        y = self.convert(self.var.y)
 
-        return tuplelist(shifts)
+        used_shifts = [shift for shift, used in y.items() if used == 1]
+        unused_shifts = [shift for shift, used in y.items() if used == 0]
 
-    def convert(self):
+        return tuplelist(used_shifts), tuplelist(unused_shifts)
+
+    def get_demand_per_shift(self):
+        """
+        Returns the number of employees needed for each shift to cover if demand exists
+        """
+
+        x = self.convert(self.var.x)
+
+        demand_for_shift = {shift: demand for shift, demand in x.items() if demand}
+
+        return tupledict(demand_for_shift)
+
+    def convert(self, var):
         """ Converts a tupledict of Gurobi variables to a tupledict of ints """
 
         # todo: move this into separate file for greater re-use
 
         converted_dict = tupledict()
-
-        var = self.var.y
 
         for key in var.keys():
             # Make sure that values are always positive


### PR DESCRIPTION
This is an MVP solution. I have extracted the demand per shift for each shift in use. I have not implemented functionality for adding shifts that SDP does not use as I want to prioritize testing if `demand_per_shift` will give additional value as soon as possible.