### PR TITLE
Add operator decay

### DIFF
--- a/heuristic/alns.py
+++ b/heuristic/alns.py
@@ -18,9 +18,10 @@ from heuristic.repair_operators import worst_week_regret_repair, worst_week_repa
 
 
 class ALNS:
-    def __init__(self, state, criterion, data, objective_weights):
+    def __init__(self, state, criterion, data, objective_weights, decay):
 
         self.objective_weights = objective_weights
+        self.decay = decay
 
         self.initial_solution = state
         self.current_solution = state
@@ -443,8 +444,13 @@ class ALNS:
     def update_weights(self, weight_update, destroy_id, repair_id):
         """ Updates the value of the operator pair by multiplying both with weight_update """
 
-        self.destroy_weights[destroy_id] *= weight_update
-        self.repair_weights[destroy_id][repair_id] *= weight_update
+        self.destroy_weights[destroy_id] = (
+                self.decay * self.destroy_weights[destroy_id] + (1-self.decay) * weight_update
+        )
+
+        self.repair_weights[destroy_id][repair_id] = (
+                self.decay * self.repair_weights[destroy_id][repair_id] + (1-self.decay) * weight_update
+        )
 
     def initialize_destroy_and_repair_weights(self):
         self.destroy_weights = self.initialize_weights(self.destroy_operators)

--- a/main.py
+++ b/main.py
@@ -67,10 +67,11 @@ class ProblemRunner:
 
         self.set_esp()
 
-    def run_alns(self, iterations=None, runtime=15, plot_objective=False, plot_violations=False):
+    def run_alns(self, decay=0.5, iterations=None, runtime=15, plot_objective=False,
+                 plot_violations=False):
         """ Runs ALNS on the generated candidate solution """
 
-        self.set_alns()
+        self.set_alns(decay)
 
         if plot_objective and plot_violations:
             raise ValueError("Cannot use two plots simultaneously")
@@ -94,7 +95,7 @@ class ProblemRunner:
 
         return self
 
-    def set_alns(self):
+    def set_alns(self, decay):
         """ Sets ALNS based on the given config """
 
         candidate_solution = self.get_candidate_solution()
@@ -130,7 +131,8 @@ class ProblemRunner:
 
         state = State(candidate_solution, soft_variables, hard_variables, objective_function, f)
 
-        self.alns = ALNS(state, self.criterion, self.data, self.weights)
+        self.alns = ALNS(state, self.criterion, self.data, self.weights, decay)
+        logger.info(f"ALNS with {decay} and {self.criterion}")
 
     def get_candidate_solution(self):
         """ Generates a candidate solution for ALNS """


### PR DESCRIPTION
Operator decay controls how sensitive the weight update is to the latest performance of the operator. A decay of 0 means that the operator pair is updated purely on the result from the lastest iteration. A decay of 1 means that the operator pair is updated based on the previous weight and the latest result is discarded. A decay of 0.5 means that both current and historic result is weighted equally. The value range for the decay is [0, 1)

<img width="985" alt="image" src="https://user-images.githubusercontent.com/1371159/82138618-18c38c00-9822-11ea-87af-32db0fe31ee9.png">
