### PR TITLE
Logg stacktrace on exception

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,8 +117,11 @@ class ProblemRunner:
         if plot_violations_bar:
             self.alns.violation_plotter = BarchartPlotter(title="Violations for current iteration",
                                                           log_name=self.log_name)
-
-        self.alns.iterate(iterations, runtime)
+        try:
+            self.alns.iterate(iterations, runtime)
+        except Exception as e:
+            logger.exception(f"An exception occured in {self.log_name}", exception=e,
+                             diagnose=True, backtrace=True)
 
         return self
 
@@ -185,7 +188,12 @@ class ProblemRunner:
             logger.info(f"Running ESP in mode {self.mode} with {len(self.esp.shifts_set['shifts'])}")
         else:
             logger.info(f"Running ESP in mode {self.mode} with implicitly generated shifts")
-        self.esp.run_model()
+
+        try:
+            self.esp.run_model()
+        except Exception as e:
+            logger.exception(f"An exception occured in {self.log_name}", exception=e,
+                             diagnose=True, backtrace=True)
 
         return self
 


### PR DESCRIPTION
<img width="1218" alt="bilde" src="https://user-images.githubusercontent.com/1371159/82685348-56764980-9c54-11ea-80fc-c5a4dde674b2.png">

This provides an significant improvement to stacktraces on exception (at least in my opinion). Logs will also indicate how the code failed, and not just stop abruptly. Furthermore they ensure that results for the ESP-run always will be saved. Can also fix a version for saving ALNS-solution if needed.