### PR TITLE
Fix operator bugs when running without sdp_reduce

### DIFF
--- a/heuristic/alns.py
+++ b/heuristic/alns.py
@@ -355,7 +355,6 @@ class ALNS:
             self.contracted_hours,
             self.t_covered_by_shift
         )
-        
 
         operators = {
             remove_worst_employee: [
@@ -380,9 +379,9 @@ class ALNS:
 
             remove_worst_week: [
                 repair_worst_week_regret,
-               repair_worst_week_greedy,
-                #repair_week_demand,
-                #repair_week_demand_per_shift,
+                repair_worst_week_greedy,
+                repair_week_demand,
+                repair_week_demand_per_shift,
                 repair_worst_week_demand_based_random,
                 repair_worst_week_demand_based_greedy,
                 mip_operator_week_repair_2
@@ -391,8 +390,8 @@ class ALNS:
             remove_random_week: [
                 repair_worst_week_regret,
                 repair_worst_week_greedy,
-                #repair_week_demand,
-                #repair_week_demand_per_shift,
+                repair_week_demand,
+                repair_week_demand_per_shift,
                 repair_worst_week_demand_based_random,
                 repair_worst_week_demand_based_greedy,
                 mip_operator_week_repair_2
@@ -401,8 +400,8 @@ class ALNS:
             remove_weighted_random_week: [
                 repair_worst_week_regret,
                 repair_worst_week_greedy,
-                #repair_week_demand,
-                #repair_week_demand_per_shift,
+                repair_week_demand,
+                repair_week_demand_per_shift,
                 repair_worst_week_demand_based_random,
                 repair_worst_week_demand_based_greedy,
                 mip_operator_week_repair_2

--- a/heuristic/repair_operators.py
+++ b/heuristic/repair_operators.py
@@ -53,11 +53,11 @@ def week_demand_per_shift_repair(shifts_in_week, competencies, t_covered_by_shif
                     shift = s
                     max_demand = d
 
-            logger.info(f"Repairing {shift} (d: {demand_per_shift[shift]})")
+            logger.info(f"Repairing {shift} (demand for shift: {demand_per_shift.get(shift)})")
 
             considered_employees = []
 
-            while demand_per_shift_in_week[shift] and number_of_employees > len(considered_employees):
+            while demand_per_shift_in_week.get(shift) and number_of_employees > len(considered_employees):
 
                 employee_score, employee = pop_from_heap(employee_heap)
                 logger.trace(f"Employee {employee} (s: {employee_score}) chosen")
@@ -123,6 +123,9 @@ def week_demand_repair(shifts_in_week, competencies, t_covered_by_shift,
         number_of_shifts = len(shift_heap)
 
         for _ in range(number_of_shifts):
+
+            if not shift_heap:
+                return repair_set
 
             shift, shift_score = get_most_valuable_shift(remaining_demand, shift_heap, t_covered_by_shift)
             allocations_needed = min([remaining_demand[t] for t in t_covered_by_shift[shift]])


### PR DESCRIPTION
The bugs in the repair operators was caused by looping over shifts with no demand, and completly repair within the for-loop, meaning no shifts remained to work with.